### PR TITLE
Add workaround for tls bug causing bad request.

### DIFF
--- a/makem.sh
+++ b/makem.sh
@@ -180,6 +180,7 @@ function run_emacs {
     output_file=$(mktemp)
     $emacs_command -Q $batch_arg \
                    --load=$package_initialize_file \
+                   --eval "(if (and (version< emacs-version \"26.3\") (>= libgnutls-version 30600))(setq gnutls-algorithm-priority \"NORMAL:-VERS-TLS1.3\"))" \
                    -L "$load_path" \
                    "$@" \
         &>$output_file


### PR DESCRIPTION
For some fairly recent versions of Emacs, a TLS-related bug causes bad request when downloading with url-retrieve-synchronously, which in my unfortunate case (using the standard Guix emacs package) happens when using makem.sh runs emacs to download dependencies. The message I get is:
```
https://elpa.gnu.org/packages/let-alist-1.0.6.el: Bad Request
ERROR (2020-01-09 17:43:19): Unable to initialize sandbox.
```

I'm not at all sure it is a good idea to add a workaround to makem.sh for this, considering the fault is not in makem.sh. It actually is probably not and this PR should be rejected. In any case, the patch in question enables me (and possibly others) to run makem.sh with the sandbox and auto-install options with our somewhat outdated Emacsen (the version number says 26.3 - but according to what I've read, the bug should have been patched in 26.3).I expect Guix to ship a patched version of Emacs sooner or later.

The TLS-related bug is described here:
  https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341
  https://www.reddit.com/r/emacs/comments/cdei4p/failed_to_download_gnu_archive_bad_request/