### PR TITLE
fix color escaping

### DIFF
--- a/makem.sh
+++ b/makem.sh
@@ -826,15 +826,15 @@ color=true
 
 # ** Colors
 
-COLOR_off='\e[0m'
-COLOR_black='\e[0;30m'
-COLOR_red='\e[0;31m'
-COLOR_green='\e[0;32m'
-COLOR_yellow='\e[0;33m'
-COLOR_blue='\e[0;34m'
-COLOR_purple='\e[0;35m'
-COLOR_cyan='\e[0;36m'
-COLOR_white='\e[0;37m'
+COLOR_off='\033[0m'
+COLOR_black='\033[0;30m'
+COLOR_red='\033[0;31m'
+COLOR_green='\033[0;32m'
+COLOR_yellow='\033[0;33m'
+COLOR_blue='\033[0;34m'
+COLOR_purple='\033[0;35m'
+COLOR_cyan='\033[0;36m'
+COLOR_white='\033[0;37m'
 
 # ** Package system args
 


### PR DESCRIPTION
Linux [man page][1] contains a list of console codes and among others it says that
`ESC` (`0x1B`, `^[`) starts an escape sequence. `0x1B` (hex) is `033` (oct).

`echo` command on Linux also [treats][3] `\e` as escape. But on BSD `\e` is not
[treated][2] as escape.

This also means that on BSD derived systems (including macOS) the output of
makem.sh is printed in an ugly fashion.

I think it makes sense to improve portability of makem.sh by using `\033`.

  [1]: https://www.unix.com/man-page/linux/4/console_codes/
  [2]: https://www.unix.com/man-page/bsd/1/echo/
  [3]: https://www.unix.com/man-page/linux/1/echo/