### PR TITLE
Fix test_files_regexp to accept *-tests.el files

### DIFF
--- a/makem.sh
+++ b/makem.sh
@@ -827,7 +827,7 @@ function test-ert {
 
 # * Defaults
 
-test_files_regexp='^((tests?|t)/)|-test.el$|^test-'
+test_files_regexp='^((tests?|t)/)|-tests?.el$|^test-'
 
 emacs_command=("emacs")
 errors=0


### PR DESCRIPTION
The pluralized name is actually the standard in Emacs core, and very
common in 3rd-party packages as well.