### PR TITLE
Fix: Escape dots in `filter-files-exclude-default` regex

### DIFF
--- a/README.org
+++ b/README.org
@@ -252,6 +252,9 @@ Checkdoc's spell checker may not recognize some words, causing the ~lint-checkdo
 + Commands in library ~makem.el~ locate the shell script automatically in the project's directories and submodules.
 + Upgrade built-in packages when installing dependencies.  ([[https://github.com/alphapapa/makem.sh/issues/41][#41]].  Thanks to [[https://ushin.org/][USHIN]] for sponsoring this fix.)
 
+*Fixed*
++ File exclusion regular expression.  ([[https://github.com/alphapapa/makem.sh/pull/32][#32]].  Thanks to [[https://github.com/fritzgrabo][Fritz Grabo]].)
+
 *Credits*
 + Thanks to [[https://ushin.org/][ushin]] for contributing the subdirectory/submodule-related changes.
 

--- a/makem.sh
+++ b/makem.sh
@@ -452,7 +452,7 @@ function dirnames {
 
 function filter-files-exclude-default {
     # Filter out paths (STDIN) which should be excluded by default.
-    grep -E -v "(/\.cask/|-autoloads.el|.dir-locals)"
+    grep -E -v "(/\.cask/|-autoloads\.el|\.dir-locals)"
 }
 
 function filter-files-exclude-args {


### PR DESCRIPTION
Just a trivial fix in the `filter-files-exclude-default` regular expression: I escaped the dots where needed to make sure the regex doesn't accidentally match when it shouldn't.

Before:

```shell
(/\.cask/|-autoloads.el|.dir-locals)
```

After:

```shell
(/\.cask/|-autoloads\.el|\.dir-locals)
```

I only noticed this because I'm working on a package named `foobar-dir-locals.el` and hit this error:

```
$ make all
ERROR (2021-02-08 23:58:35): No files specified and not in a git repo.
make: *** [all] Error 1
```

With the proposed fix in place, everything works as expected.

PS: Thanks so much for this script -- together with Steve Purcell's `package-lint`, it's been a great help as I start writing and publishing my first packages 🙌 