### PR TITLE
Change: Replace egrep usage with grep -E

### DIFF
--- a/README.org
+++ b/README.org
@@ -262,6 +262,9 @@ Checkdoc's spell checker may not recognize some words, causing the ~lint-checkdo
 +  Rule ~lint-indent~ for Emacs 28.
 +  Install Ispell in CI for ~checkdoc~ linting.
 
+*Internal*
++ Use ~grep -E~ instead of ~egrep~.  ([[https://github.com/alphapapa/makem.sh/pull/38][#38]].  Thanks to [[https://github.com/jameschensmith][James Chen-Smith]].)
+
 ** 0.5
 
 *Changed*

--- a/makem.sh
+++ b/makem.sh
@@ -395,7 +395,7 @@ function dirs-project {
 function files-project-elisp {
     # Echo list of Elisp files in project.
     git ls-files 2>/dev/null \
-        | egrep "\.el$" \
+        | grep -E "\.el$" \
         | filter-files-exclude-default \
         | filter-files-exclude-args
 }
@@ -403,13 +403,13 @@ function files-project-elisp {
 function files-project-feature {
     # Echo list of Elisp files that are not tests and provide a feature.
     files-project-elisp \
-        | egrep -v "$test_files_regexp" \
+        | grep -E -v "$test_files_regexp" \
         | filter-files-feature
 }
 
 function files-project-test {
     # Echo list of Elisp test files.
-    files-project-elisp | egrep "$test_files_regexp"
+    files-project-elisp | grep -E "$test_files_regexp"
 }
 
 function dirnames {
@@ -422,7 +422,7 @@ function dirnames {
 
 function filter-files-exclude-default {
     # Filter out paths (STDIN) which should be excluded by default.
-    egrep -v "(/\.cask/|-autoloads.el|.dir-locals)"
+    grep -E -v "(/\.cask/|-autoloads.el|.dir-locals)"
 }
 
 function filter-files-exclude-args {
@@ -448,7 +448,7 @@ function filter-files-feature {
     # Read paths on STDIN and echo ones that (provide 'a-feature).
     while read path
     do
-        egrep "^\\(provide '" "$path" &>/dev/null \
+        grep -E "^\\(provide '" "$path" &>/dev/null \
             && echo "$path"
     done
 }
@@ -519,16 +519,16 @@ function dependencies {
 
     # Search package headers.  Use -a so grep won't think that an Elisp file containing
     # control characters (rare, but sometimes necessary) is binary and refuse to search it.
-    egrep -a -i '^;; Package-Requires: ' $(files-project-feature) $(files-project-test) \
-        | egrep -o '\([^([:space:]][^)]*\)' \
-        | egrep -o '^[^[:space:])]+' \
+    grep -E -a -i '^;; Package-Requires: ' $(files-project-feature) $(files-project-test) \
+        | grep -E -o '\([^([:space:]][^)]*\)' \
+        | grep -E -o '^[^[:space:])]+' \
         | sed -r 's/\(//g' \
-        | egrep -v '^emacs$'  # Ignore Emacs version requirement.
+        | grep -E -v '^emacs$'  # Ignore Emacs version requirement.
 
     # Search Cask file.
     if [[ -r Cask ]]
     then
-        egrep '\(depends-on "[^"]+"' Cask \
+        grep -E '\(depends-on "[^"]+"' Cask \
             | sed -r -e 's/\(depends-on "([^"]+)".*/\1/g'
     fi
 


### PR DESCRIPTION
#### Summary

Replaces deprecated usage of `egrep` with `grep -E`. Resolves the warning `egrep: warning: egrep is obsolescent; using grep -E`.

> **What happened to egrep and fgrep?**
>
> 7th Edition Unix had commands egrep and fgrep that were the counterparts of the modern ‘grep -E’ and ‘grep -F’. Although breaking up grep into three programs was perhaps useful on the small computers of the 1970s, egrep and fgrep were deemed obsolescent by POSIX in 1992, removed from POSIX in 2001, deprecated by GNU Grep 2.5.3 in 2007, and changed to issue obsolescence warnings by GNU Grep 3.8 in 2022; eventually, they are planned to be removed entirely. 

&mdash; [Usage - GNU Grep (section "What happened to egrep and fgrep?")](https://www.gnu.org/software/grep/manual/html_node/Usage.html)