### PR TITLE
Change: (elisp-checkdoc-file) Respect .dir-local ispell LocalWords

### DIFF
--- a/README.org
+++ b/README.org
@@ -152,6 +152,12 @@ The script may be called directly to specify additional options.
   specified with options.  Package dependencies are discovered from
   "Package-Requires" headers in source files, from -pkg.el files, and
   from a Cask file.
+
+  Checkdoc's spell checker may not recognize some words, causing the
+  `lint-checkdoc' rule to fail.  Custom words can be added in file-local
+  or directory-local variables using the variable
+  `ispell-buffer-session-localwords', which should be set to a list of
+  strings.
 #+END_EXAMPLE
 
 ** Transient menu (=makem.el=)
@@ -235,6 +241,10 @@ It's often helpful to run tests automatically before pushing with git.  Here's a
   make test
 #+END_SRC
 
+** Spell checking
+
+Checkdoc's spell checker may not recognize some words, causing the ~lint-checkdoc~ rule to fail.  Custom words can be added in file-local or directory-local variables using the variable ~ispell-buffer-session-localwords~, which should be set to a list of strings.
+
 * Changelog
 :PROPERTIES:
 :TOC:      :ignore children
@@ -245,6 +255,7 @@ It's often helpful to run tests automatically before pushing with git.  Here's a
 *Added*
 +  ~lint-elint~ rule (not enabled by default in ~lint~ rule due to Elint's output not seeming very useful).
 +  =makem.el= library with Transient dispatcher.
++  Custom words for spell checking may be set in a file- or directory-local variable, ~ispell-buffer-session-localwords~.  (Thanks to [[https://github.com/josephmturner][Joseph Turner]].)
 
 *Fixed*
 +  Set ~package-user-dir~ (needed for Emacs 28 compatibility).

--- a/makem.sh
+++ b/makem.sh
@@ -177,6 +177,7 @@ function elisp-checkdoc-file {
               (setq makem-checkdoc-errors-p t)
               ;; Return nil because we *are* generating a buffered list of errors.
               nil))))
+    (put 'ispell-buffer-session-localwords 'safe-local-variable #'list-of-strings-p)
     (mapcar #'checkdoc-file files)
     (when makem-checkdoc-errors-p
       (kill-emacs 1))))

--- a/makem.sh
+++ b/makem.sh
@@ -112,6 +112,12 @@ Source files are automatically discovered from git, or may be
 specified with options.  Package dependencies are discovered from
 "Package-Requires" headers in source files, from -pkg.el files, and
 from a Cask file.
+
+Checkdoc's spell checker may not recognize some words, causing the
+`lint-checkdoc' rule to fail.  Custom words can be added in file-local
+or directory-local variables using the variable
+`ispell-buffer-session-localwords', which should be set to a list of
+strings.
 EOF
 }
 


### PR DESCRIPTION
This commit makes it possible to define a directory-wide list of words that checkdoc's spellcheck should ignore.

A more general solution that allows users to mark dir-local/file-local variables as safe may be desired.