### PR TITLE
Fix: (makem transient): Properly autoload

### DIFF
--- a/makem.el
+++ b/makem.el
@@ -38,7 +38,7 @@
 
 ;; FIXME: Some of the infixes seem to incorrectly share whole-transient history.
 
-;;;###autoload
+;;;###autoload (autoload 'makem "makem" nil t)
 (transient-define-prefix makem ()
   "Transient for running makem.sh."
   [:pad-keys t


### PR DESCRIPTION
The autoload machinery doesn't know about `transient-define-prefix`,
so the long form has to be used.  Otherwise an error is signaled when
loading the autoloads file:

```
Error loading autoloads: (void-function transient-prefix)
```