### PR TITLE
Escape backticks in makem.sh usage heredoc

### DIFF
--- a/README.org
+++ b/README.org
@@ -250,6 +250,9 @@ Checkdoc's spell checker may not recognize some words, causing the ~lint-checkdo
 *Changes*
 + Don't initialize package system when not necessary (as initializing the package system causes some other libraries, like ~url~, to be loaded, which can obscure problems which might occur otherwise).  ([[https://github.com/alphapapa/makem.sh/issues/47][#47]].  Thanks to [[https://github.com/josephmturner][Joseph Turner]] for reporting.)
 
+*Fixes*
++ Escape backticks in ~makem.sh~'s ~usage~ function's Bash here-document.  (Thanks to [[https://github.com/snogge][Ola Nilsson]].)
+
 *Compatibility*
 + Restore compatibility with Bash versions earlier than 4.0 (e.g. on Mac OS).  ([[https://github.com/alphapapa/makem.sh/pull/49][#49]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 

--- a/makem.sh
+++ b/makem.sh
@@ -114,9 +114,9 @@ specified with options.  Package dependencies are discovered from
 from a Cask file.
 
 Checkdoc's spell checker may not recognize some words, causing the
-`lint-checkdoc' rule to fail.  Custom words can be added in file-local
+\`lint-checkdoc' rule to fail.  Custom words can be added in file-local
 or directory-local variables using the variable
-`ispell-buffer-session-localwords', which should be set to a list of
+\`ispell-buffer-session-localwords', which should be set to a list of
 strings.
 EOF
 }


### PR DESCRIPTION
The content of heredocs are expanded both for variables and subshell commands, this means backticks must be escaped.

The alternative would be to quote the heredoc like this
```bash
cat <<'EOF'
Backticks are `fine'.
EOF
```
But then the `$0` parameter would not be expanded.