### PR TITLE
Fix "No files specified and not in a git repo" error on older bash versions

### DIFF
--- a/README.org
+++ b/README.org
@@ -248,7 +248,10 @@ Checkdoc's spell checker may not recognize some words, causing the ~lint-checkdo
 ** 0.8-pre
 
 *Changes*
-+ Don't initialize package system when not necessary.  (Initializing the package system causes some other libraries, like ~url~, to be loaded, which can obscure problems which might occur otherwise.  [[https://github.com/alphapapa/makem.sh/issues/47][#47]].  Thanks to [[https://github.com/josephmturner][Joseph Turner]] for reporting.) 
++ Don't initialize package system when not necessary.  (Initializing the package system causes some other libraries, like ~url~, to be loaded, which can obscure problems which might occur otherwise.  [[https://github.com/alphapapa/makem.sh/issues/47][#47]].  Thanks to [[https://github.com/josephmturner][Joseph Turner]] for reporting.)
+
+*Compatibility*
++ Restore compatibility with Bash versions earlier than 4.0 (e.g. on Mac OS).  ([[https://github.com/alphapapa/makem.sh/pull/49][#49]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 
 ** 0.7.1
 

--- a/makem.sh
+++ b/makem.sh
@@ -396,7 +396,7 @@ function files-project {
     # matching that pattern with "git ls-files".  Excludes submodules.
     [[ $1 ]] && pattern="/$1" || pattern="."
 
-    local excludes
+    local excludes=()
     for submodule in $(submodules)
     do
         excludes+=(":!:$submodule")

--- a/makem.sh
+++ b/makem.sh
@@ -414,7 +414,7 @@ function dirs-project {
 function files-project-elisp {
     # Echo list of Elisp files in project.
     files-project 2>/dev/null \
-        | egrep "\.el$" \
+        | grep -E "\.el$" \
         | filter-files-exclude-default \
         | filter-files-exclude-args
 }


### PR DESCRIPTION
On bash-3.2 and older, this code passes a single empty "excludes" argument to
`git ls-files` instead of no arguments, which causes it to print no
output (and the error is swallowed by `2>/dev/null`):

```sh
local excludes

<snip>

git ls-files ... "${excludes[@]}"
```

Since macOS runners on GitHub Actions have this old version of bash, I
personally think it would be convenient to fix this incompatibility
here, rather than forcing the CI workflows to install a new bash
version.